### PR TITLE
[Feat] 게임 생성/오답 페이지 관련 api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	// AWS S3 사용
 	// implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 
+	// PDF 텍스트 추출
+	implementation 'org.apache.pdfbox:pdfbox:3.0.3'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/src/main/java/growth/_OK/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/growth/_OK/backend/auth/controller/AuthController.java
@@ -4,6 +4,9 @@ import growth._OK.backend.auth.dto.request.GoogleCodeRequest;
 import growth._OK.backend.auth.dto.response.TokenResponse;
 import growth._OK.backend.auth.jwt.CustomUserDetails;
 import growth._OK.backend.auth.service.AuthService;
+import growth._OK.backend.user.dto.request.UserBasicInfoRequestDto;
+import growth._OK.backend.user.dto.response.UserBasicInfoResponseDto;
+import growth._OK.backend.user.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,13 +20,16 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserService userService;
 
+    // 로그인
     @PostMapping("/google")
     public ResponseEntity<Void> loginOrRegister(@RequestBody GoogleCodeRequest request, HttpServletResponse response) {
         authService.googleLogin(request, response);
         return ResponseEntity.ok().build();
     }
 
+    // 리이슈
     @PostMapping("/refresh")
     public ResponseEntity<Void> refresh(
             @CookieValue("refresh_token") String refreshToken,
@@ -33,6 +39,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails user,
                                        HttpServletResponse response,
@@ -41,6 +48,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    // 계정 삭제
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteAccount(@AuthenticationPrincipal CustomUserDetails user,
                                               @RequestHeader("Authorization") String accessToken,
@@ -49,7 +57,21 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    // 기본 정보 조회
+    @GetMapping("/me")
+    public ResponseEntity<UserBasicInfoResponseDto> getMyBasicInfo(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        UserBasicInfoResponseDto dto = userService.getBasicInfo(user.getUser().getUserId());
+        return ResponseEntity.ok(dto);
+    }
 
-
-
+    // 기본 정보 수정
+    @PatchMapping("/me")
+    public ResponseEntity<UserBasicInfoResponseDto> updateMyBasicInfo(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody UserBasicInfoRequestDto request) {
+        UserBasicInfoResponseDto dto = userService.updateBasicInfo(
+                user.getUser().getUserId(), request);
+        return ResponseEntity.ok(dto);
+    }
 }

--- a/backend/src/main/java/growth/_OK/backend/game/controller/GameController.java
+++ b/backend/src/main/java/growth/_OK/backend/game/controller/GameController.java
@@ -2,9 +2,17 @@ package growth._OK.backend.game.controller;
 
 import growth._OK.backend.auth.jwt.CustomUserDetails;
 import growth._OK.backend.game.dto.ResponseDto.GameListResponseDto;
+import growth._OK.backend.game.dto.ResponseDto.GamePreviewResponseDto;
+import growth._OK.backend.game.dto.ResponseDto.GeneratedProblemDto;
 import growth._OK.backend.game.dto.ResponseDto.GameResponseDto;
+import growth._OK.backend.game.dto.ResponseDto.ProblemWithStatusDto;
 import growth._OK.backend.game.dto.requestDto.GameCreateRequestDto;
+import growth._OK.backend.game.dto.requestDto.GameGenerateProblemsRequestDto;
+import growth._OK.backend.game.dto.requestDto.SubmitAnswerRequestDto;
+import growth._OK.backend.game.service.GameGenerateService;
 import growth._OK.backend.game.service.GameService;
+import growth._OK.backend.game.service.GameSourceService;
+import growth._OK.backend.game.service.ProblemAttemptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,25 +21,93 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 
 @RestController
-@RequestMapping("/api/games")
+@RequestMapping("/games")
 @RequiredArgsConstructor
 public class GameController {
 
     private final GameService gameService;
+    private final GameSourceService gameSourceService;
+    private final GameGenerateService gameGenerateService;
+    private final ProblemAttemptService problemAttemptService;
 
-    // 게임 생성 
+    // 게임 생성
     @PostMapping
     public ResponseEntity<GameResponseDto> createGame(@AuthenticationPrincipal CustomUserDetails user,
                                                       @RequestBody GameCreateRequestDto request) {
         GameResponseDto created = gameService.createGame(request, user);
-        URI location = URI.create("/api/games/" + created.getId());
+        URI location = URI.create("/games/" + created.getId());
         return ResponseEntity.created(location).body(created);
+    }
+
+    // 소스 업로드 (PDF/텍스트). 해당 게임에 연결. 먼저 POST /games 로 게임 생성 후 호출.
+    @PostMapping("/{gameId}/sources")
+    public ResponseEntity<Map<String, Long>> uploadSource(@PathVariable Long gameId,
+                                                          @AuthenticationPrincipal CustomUserDetails user,
+                                                          @RequestParam("file") MultipartFile file) {
+        Long sourceId = gameSourceService.uploadSource(gameId, file, user);
+        return ResponseEntity.ok(Map.of("sourceId", sourceId));
+    }
+
+    // 1단계: 게임 설명, 학습 목표, 학습할 내용만 먼저 반환. 게임에 연결된 소스 사용. 소스 없으면 에러.
+    @PostMapping("/{gameId}/generate/preview")
+    public ResponseEntity<GamePreviewResponseDto> generatePreview(@PathVariable Long gameId,
+                                                                  @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseEntity.ok(gameGenerateService.generatePreview(gameId, user));
+    }
+
+    // 2단계: 게임 문제 생성 후 해당 게임에 저장. 게임에 연결된 소스로 생성.
+    @PostMapping("/{gameId}/generate/problems")
+    public ResponseEntity<Map<String, List<GeneratedProblemDto>>> generateProblems(
+            @PathVariable Long gameId,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody GameGenerateProblemsRequestDto request) {
+        return ResponseEntity.ok(Map.of("problems", gameGenerateService.generateProblems(gameId, request, user)));
+    }
+
+    // 문제 제출: 정답/오답 기록. body: { "correct": true | false }
+    @PostMapping("/{gameId}/problems/{problemId}/submit")
+    public ResponseEntity<Void> submitAnswer(@PathVariable Long gameId,
+                                             @PathVariable Long problemId,
+                                             @AuthenticationPrincipal CustomUserDetails user,
+                                             @RequestBody SubmitAnswerRequestDto request) {
+        if (request.getCorrect() == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        problemAttemptService.submitAnswer(gameId, problemId, request.getCorrect(), user);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 틀린 문제만 조회 (오답 노트). 첫 시도에서 오답이었던 문제 목록
+    @GetMapping("/{gameId}/problems/wrong")
+    public ResponseEntity<List<ProblemWithStatusDto>> getWrongProblems(@PathVariable Long gameId,
+                                                                        @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseEntity.ok(problemAttemptService.getWrongProblems(gameId, user));
+    }
+
+    // 문제 해설 조회. 없으면 Gemini로 생성 후 저장하고 반환. GET 또는 POST 모두 지원
+    @RequestMapping(value = "/{gameId}/problems/{problemId}/explanation", method = {RequestMethod.GET, RequestMethod.POST})
+    public ResponseEntity<Map<String, String>> getExplanation(@PathVariable Long gameId,
+                                                              @PathVariable Long problemId,
+                                                              @AuthenticationPrincipal CustomUserDetails user) {
+        String explanation = problemAttemptService.getOrCreateExplanation(gameId, problemId, user);
+        return ResponseEntity.ok(Map.of("explanation", explanation != null ? explanation : ""));
+    }
+
+    /** 문제 전체 조회. 각 문제별 상태(맞음/틀림/오답 후 정답) + 해설. 해설 없으면 Gemini로 생성 후 포함 */
+    @GetMapping("/{gameId}/problems")
+    public ResponseEntity<List<ProblemWithStatusDto>> getAllProblems(@PathVariable Long gameId,
+                                                                      @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseEntity.ok(problemAttemptService.getAllProblemsWithStatusAndExplanation(gameId, user));
     }
 
     // 게임 전체 조회 + 제목 검색

--- a/backend/src/main/java/growth/_OK/backend/game/domain/Game.java
+++ b/backend/src/main/java/growth/_OK/backend/game/domain/Game.java
@@ -2,27 +2,19 @@ package growth._OK.backend.game.domain;
 
 import growth._OK.backend.global.domain.BaseEntity;
 import growth._OK.backend.user.domain.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "games")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Game extends BaseEntity {
+
+    private static final int DEFAULT_PROBLEM_COUNT = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +31,12 @@ public class Game extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
+
+    // 학습 목표
+    @Column(name = "learning_objectives", columnDefinition = "TEXT")
+    private String learningObjectives;
 
     @Column(name = "is_public", nullable = false)
     private boolean isPublic;
@@ -48,14 +44,39 @@ public class Game extends BaseEntity {
     @Column(nullable = false)
     private int likeCount;
 
+    // 게임에 포함될 문제 갯수 (기본: 10개)
+    @Column(name = "problem_count", nullable = false)
+    private int problemCount;
+
+    // 허용 문제 유형 (단답형, O/X, 5지선다 중 선택)
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "game_allowed_problem_types", joinColumns = @JoinColumn(name = "game_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "problem_type", length = 20)
+    private List<ProblemType> allowedProblemTypes = new ArrayList<>();
+
+    // 이 게임의 출제 소스 (업로드한 PDF/텍스트). 문제 생성 시 사용. null이면 문제 생성 불가
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "source_id", nullable = true)
+    private GameSource source;
+
+    @OneToMany(mappedBy = "game", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OrderBy("sortOrder")
+    private List<Problem> problems = new ArrayList<>();
+
     @Builder
-    public Game(User owner, GameType type, String title, String description, boolean isPublic) {
+    public Game(User owner, GameType type, String title, String description, String learningObjectives,
+                boolean isPublic, int problemCount, List<ProblemType> allowedProblemTypes, GameSource source) {
         this.owner = owner;
         this.type = type;
         this.title = title;
         this.description = description;
+        this.learningObjectives = learningObjectives;
         this.isPublic = isPublic;
         this.likeCount = 0;
+        this.problemCount = problemCount <= 0 ? DEFAULT_PROBLEM_COUNT : problemCount;
+        this.allowedProblemTypes = allowedProblemTypes != null ? new ArrayList<>(allowedProblemTypes) : new ArrayList<>();
+        this.source = source;
     }
 
     public void increaseLikeCount() {
@@ -66,5 +87,10 @@ public class Game extends BaseEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
+    }
+
+    // 해당 게임에 소스 연결 (소스 업로드 시 호출)
+    public void setSource(GameSource source) {
+        this.source = source;
     }
 }

--- a/backend/src/main/java/growth/_OK/backend/game/dto/ResponseDto/GameResponseDto.java
+++ b/backend/src/main/java/growth/_OK/backend/game/dto/ResponseDto/GameResponseDto.java
@@ -2,10 +2,12 @@ package growth._OK.backend.game.dto.ResponseDto;
 
 import growth._OK.backend.game.domain.Game;
 import growth._OK.backend.game.domain.GameType;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import growth._OK.backend.game.domain.ProblemType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -16,9 +18,12 @@ public class GameResponseDto {
     private final GameType type;
     private final String title;
     private final String description;
+    private final String learningObjectives;
     private final int likeCount;
     private final boolean isLiked;
     private final boolean isPublic;
+    private final int problemCount;
+    private final List<ProblemType> problemTypes;
 
     public static GameResponseDto from(Game game) {
         return GameResponseDto.builder()
@@ -27,9 +32,12 @@ public class GameResponseDto {
                 .type(game.getType())
                 .title(game.getTitle())
                 .description(game.getDescription())
+                .learningObjectives(game.getLearningObjectives())
                 .likeCount(game.getLikeCount())
                 .isLiked(false)
                 .isPublic(game.isPublic())
+                .problemCount(game.getProblemCount())
+                .problemTypes(game.getAllowedProblemTypes() != null ? List.copyOf(game.getAllowedProblemTypes()) : List.of())
                 .build();
     }
 
@@ -40,9 +48,12 @@ public class GameResponseDto {
                 .type(game.getType())
                 .title(game.getTitle())
                 .description(game.getDescription())
+                .learningObjectives(game.getLearningObjectives())
                 .likeCount(game.getLikeCount())
                 .isLiked(isLiked)
                 .isPublic(game.isPublic())
+                .problemCount(game.getProblemCount())
+                .problemTypes(game.getAllowedProblemTypes() != null ? List.copyOf(game.getAllowedProblemTypes()) : List.of())
                 .build();
     }
 }

--- a/backend/src/main/java/growth/_OK/backend/game/dto/requestDto/GameCreateRequestDto.java
+++ b/backend/src/main/java/growth/_OK/backend/game/dto/requestDto/GameCreateRequestDto.java
@@ -1,9 +1,12 @@
 package growth._OK.backend.game.dto.requestDto;
 
 import growth._OK.backend.game.domain.GameType;
+import growth._OK.backend.game.domain.ProblemType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -12,5 +15,12 @@ public class GameCreateRequestDto {
     private final GameType type;
     private final String title;
     private final String description;
+    private final String learningObjectives;
     private final Boolean isPublic;
+    // 허용 문제 유형 (단답형, O/X, 5지선다). 비어 있으면 전체 허용
+    private final List<ProblemType> problemTypes;
+    // 문제 개수. null이거나 0 이하면 기본 10개
+    private final Integer problemCount;
+    // 이 게임에 연결할 소스 ID (업로드한 PDF/텍스트). 지정 시 문제 생성 시 해당 소스 사용
+    private final Long sourceId;
 }

--- a/backend/src/main/java/growth/_OK/backend/game/service/GameService.java
+++ b/backend/src/main/java/growth/_OK/backend/game/service/GameService.java
@@ -6,8 +6,10 @@ import growth._OK.backend.game.domain.GameLike;
 import growth._OK.backend.game.dto.ResponseDto.GameListResponseDto;
 import growth._OK.backend.game.dto.ResponseDto.GameResponseDto;
 import growth._OK.backend.game.dto.requestDto.GameCreateRequestDto;
+import growth._OK.backend.game.domain.GameSource;
 import growth._OK.backend.game.repository.GameLikeRepository;
 import growth._OK.backend.game.repository.GameRepository;
+import growth._OK.backend.game.repository.GameSourceRepository;
 import growth._OK.backend.global.exception.CapstonException;
 import growth._OK.backend.global.exception.ExceptionCode;
 import growth._OK.backend.user.domain.User;
@@ -25,19 +27,35 @@ public class GameService {
 
     private final GameRepository gameRepository;
     private final GameLikeRepository gameLikeRepository;
+    private final GameSourceRepository gameSourceRepository;
     private final UserRepository userRepository;
 
     // 게임 생성
     public GameResponseDto createGame(GameCreateRequestDto request, CustomUserDetails userDetails) {
-
         User owner = findUser(userDetails);
+        int problemCount = (request.getProblemCount() == null || request.getProblemCount() <= 0)
+                ? 10
+                : request.getProblemCount();
+
+        GameSource source = null;
+        if (request.getSourceId() != null) {
+            source = gameSourceRepository.findById(request.getSourceId())
+                    .orElseThrow(() -> new CapstonException(ExceptionCode.GAME_SOURCE_NOT_FOUND));
+            if (!source.getOwner().getUserId().equals(owner.getUserId())) {
+                throw new CapstonException(ExceptionCode.GAME_SOURCE_NOT_FOUND);
+            }
+        }
 
         Game game = Game.builder()
                 .owner(owner)
                 .type(request.getType())
                 .title(request.getTitle())
                 .description(request.getDescription())
+                .learningObjectives(request.getLearningObjectives())
                 .isPublic(request.getIsPublic() == null || request.getIsPublic())
+                .problemCount(problemCount)
+                .allowedProblemTypes(request.getProblemTypes() != null ? request.getProblemTypes() : List.of())
+                .source(source)
                 .build();
 
         return GameResponseDto.from(gameRepository.save(game));

--- a/backend/src/main/java/growth/_OK/backend/global/exception/ClientExceptionCode.java
+++ b/backend/src/main/java/growth/_OK/backend/global/exception/ClientExceptionCode.java
@@ -16,4 +16,11 @@ public enum ClientExceptionCode {
 
     // 게임
     GAME_NOT_FOUND,
+    PROBLEM_NOT_FOUND,
+    GAME_SOURCE_NOT_FOUND,
+    GAME_SOURCE_NOT_SET,
+    INVALID_SOURCE_FILE,
+
+    // AI (Gemini)
+    GEMINI_QUOTA_EXCEEDED,
 }

--- a/backend/src/main/java/growth/_OK/backend/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/growth/_OK/backend/global/exception/ExceptionCode.java
@@ -19,6 +19,13 @@ public enum ExceptionCode {
 
     // 게임
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.GAME_NOT_FOUND, "찾을 수 없는 게임입니다."),
+    PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.PROBLEM_NOT_FOUND, "찾을 수 없는 문제입니다."),
+    GAME_SOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.GAME_SOURCE_NOT_FOUND, "찾을 수 없는 소스입니다."),
+    GAME_SOURCE_NOT_SET(HttpStatus.BAD_REQUEST, ClientExceptionCode.GAME_SOURCE_NOT_SET, "해당 게임에 연결된 소스가 없습니다. 게임 생성 시 sourceId를 지정해 주세요."),
+    INVALID_SOURCE_FILE(HttpStatus.BAD_REQUEST, ClientExceptionCode.INVALID_SOURCE_FILE, "PDF 또는 텍스트 파일만 업로드 가능합니다."),
+
+    // AI (Gemini)
+    GEMINI_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, ClientExceptionCode.GEMINI_QUOTA_EXCEEDED, "AI 생성 요청 한도를 초과했습니다. 잠시 후 다시 시도해 주세요."),
     ;
     private final HttpStatus httpStatus;
     private final ClientExceptionCode clientExceptionCode;

--- a/backend/src/main/java/growth/_OK/backend/user/domain/User.java
+++ b/backend/src/main/java/growth/_OK/backend/user/domain/User.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 
 @Entity
 @Getter
@@ -30,6 +32,14 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role = Role.STUDENT;
+
+    // 기본 정보 (로그인 후 입력/조회)
+    private Integer birthYear;   // 필수
+    private String grade;       // 필수 (예: 초등1, 중1, 고2)
+    private LocalDate birthDate; // 선택
+    private String school;      // 선택
+    @Enumerated(EnumType.STRING)
+    private Gender gender;      // 선택
 
     // ---------------
 
@@ -63,6 +73,17 @@ public class User extends BaseEntity {
     // 프로필 사진 수정
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    // 기본 정보 수정
+    public void updateBasicInfo(String name, Integer birthYear, String grade,
+                               LocalDate birthDate, String school, Gender gender) {
+        if (name != null) this.name = name;
+        if (birthYear != null) this.birthYear = birthYear;
+        if (grade != null) this.grade = grade;
+        if (birthDate != null) this.birthDate = birthDate;
+        if (school != null) this.school = school;
+        if (gender != null) this.gender = gender;
     }
 
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -38,3 +38,8 @@ oauth:
 
 jwt:
   secret: ${JWT_SECRET}
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+  model: gemini-2.5-flash
+  generate-content-url: https://generativelanguage.googleapis.com/v1beta/models


### PR DESCRIPTION
## 어떤 기능인가요?
> 게임 생성 page 관련 api
> 게임 오답 page 관련 api

## 작업 상세 내용
- [x] 게임에 들어가는 source 업로드 (PDF or TEXT)
- [x] Gemini를 통해 게임의 학습목표, 설명, 학습 내용 생성
- [x] Gemini를 통해 게임의 문제 생성
- [x] 게임의 정답/오답 유무 입력
- [x] 오답 문제 전체 조회
- [x] 문제 전체 조회(오답 다하고 정답/오답/오답후 맞춤 상태도 알려줌)
- [x] 해설 조회/생성 (해설이 없다면 자동으로 gemeni로 생성) 
- [x] 로그인 시 기본 정보 입력 (auth branch에서 업로드 했어야 했는데 실수함..) 

## 테스트 결과 
- 게임에 들어가는 source 업로드 (PDF or TEXT)
<img width="1219" height="534" alt="image" src="https://github.com/user-attachments/assets/84b157ab-cbf9-4f79-b9fe-ea2872635733" />

- Gemini를 통해 게임의 학습목표, 설명, 학습 내용 생성
<img width="1383" height="697" alt="image" src="https://github.com/user-attachments/assets/c08751cc-958a-42cf-ab1c-b2f5ec180a32" />

- Gemini를 통해 게임의 문제 생성
<img width="1360" height="776" alt="image" src="https://github.com/user-attachments/assets/8ccd7201-37c0-4275-8be4-75b0352e7c33" />

- 해설 조회/생성 (해설이 없다면 자동으로 gemini로 생성) 
<img width="1335" height="519" alt="image" src="https://github.com/user-attachments/assets/e71b0b10-839e-4dc2-921e-767e25b15d69" />


## Trouble Shooting 
별거 없었음. 
gemini 요청시에 토큰을 다 쓰면 500에러를 줘서 잘 알아볼 수 있게 429에러로 고침

## 관련 이슈

