### PR TITLE
feat: FastAPI NLP 서버 연동 및 Vite Proxy 설정 추가

### DIFF
--- a/backend/src/main/java/growth/_OK/backend/game/client/NlpClient.java
+++ b/backend/src/main/java/growth/_OK/backend/game/client/NlpClient.java
@@ -1,0 +1,159 @@
+package growth._OK.backend.game.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import growth._OK.backend.game.domain.ProblemType;
+import growth._OK.backend.game.service.GeminiService;
+import growth._OK.backend.global.config.NlpProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FastAPI NLP 서버 클라이언트
+ * POST /api/generate/problems → GeminiService.RawGeneratedProblem 리스트로 변환
+ *
+ * nlp.enabled=false 이거나 서버 응답 실패 시 null 반환 → GameGenerateService에서 Gemini fallback
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NlpClient {
+
+    private final NlpProperties nlpProperties;
+    private final WebClient.Builder webClientBuilder;
+    private final ObjectMapper objectMapper;
+
+    // ── FastAPI 요청 body ──────────────────────────────────────────────────────
+
+    public record NlpGenerateRequest(
+            @JsonProperty("source_text")    String sourceText,
+            @JsonProperty("grammar_tags")   List<String> grammarTags,
+            @JsonProperty("problem_count")  int problemCount,
+            @JsonProperty("problem_types")  List<String> problemTypes,
+            @JsonProperty("personalization_context") String personalizationContext
+    ) {}
+
+    // ── FastAPI 응답 body ─────────────────────────────────────────────────────
+
+    public record NlpProblem(
+            String question,
+            List<String> options,
+            @JsonProperty("correct_answer") String correctAnswer,
+            String type,
+            String scope
+    ) {}
+
+    public record NlpGenerateResponse(
+            List<NlpProblem> problems,
+            @JsonProperty("source_sentences") List<String> sourceSentences,
+            @JsonProperty("grammar_tags_used") List<String> grammarTagsUsed
+    ) {}
+
+    // ── 핵심 메서드 ────────────────────────────────────────────────────────────
+
+    /**
+     * FastAPI 서버에 문제 생성 요청.
+     *
+     * @param sourceText             사용자 업로드 텍스트 (null 가능 — corpus에서 자동 검색)
+     * @param grammarTags            취약점 기반 grammar tag 목록 (null 가능)
+     * @param problemCount           생성할 문제 수
+     * @param problemTypes           문제 유형 목록
+     * @param personalizationContext AnalysisService에서 만든 사용자 취약점 JSON 문자열
+     * @return 파싱된 문제 목록. 실패 시 null 반환 → 호출부에서 Gemini fallback 처리
+     */
+    public List<GeminiService.RawGeneratedProblem> generateProblems(
+            String sourceText,
+            List<String> grammarTags,
+            int problemCount,
+            List<ProblemType> problemTypes,
+            String personalizationContext
+    ) {
+        if (!nlpProperties.isEnabled()) {
+            log.info("[NlpClient] nlp.enabled=false, skipping NLP server call");
+            return null;
+        }
+
+        List<String> typeNames = problemTypes == null || problemTypes.isEmpty()
+                ? List.of("MULTIPLE_CHOICE", "OX", "SHORT_ANSWER")
+                : problemTypes.stream().map(Enum::name).toList();
+
+        NlpGenerateRequest requestBody = new NlpGenerateRequest(
+                sourceText,
+                grammarTags,
+                problemCount,
+                typeNames,
+                personalizationContext
+        );
+
+        try {
+            NlpGenerateResponse response = webClientBuilder.build()
+                    .post()
+                    .uri(nlpProperties.getServerUrl() + "/api/generate/problems")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(NlpGenerateResponse.class)
+                    .block(Duration.ofSeconds(nlpProperties.getTimeoutSeconds()));
+
+            if (response == null || response.problems() == null || response.problems().isEmpty()) {
+                log.warn("[NlpClient] Empty response from NLP server");
+                return null;
+            }
+
+            log.info("[NlpClient] Received {} problems from NLP server (tags: {})",
+                    response.problems().size(),
+                    response.grammarTagsUsed());
+
+            return response.problems().stream()
+                    .map(this::toRaw)
+                    .toList();
+
+        } catch (Exception e) {
+            log.warn("[NlpClient] NLP server call failed ({}): {} — falling back to Gemini",
+                    nlpProperties.getServerUrl(), e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * FastAPI 응답 → GeminiService.RawGeneratedProblem 변환
+     * 기존 GameGenerateService 로직을 그대로 재사용할 수 있게 맞춤
+     */
+    private GeminiService.RawGeneratedProblem toRaw(NlpProblem p) {
+        GeminiService.RawGeneratedProblem raw = new GeminiService.RawGeneratedProblem();
+        raw.question      = p.question();
+        raw.options       = p.options() != null ? p.options() : List.of();
+        raw.correctAnswer = p.correctAnswer();
+        raw.type          = p.type();
+        raw.scope         = p.scope();
+        return raw;
+    }
+
+    // ── 헬스체크 ───────────────────────────────────────────────────────────────
+
+    /**
+     * NLP 서버 상태 확인 (로컬 테스트용)
+     */
+    public boolean isHealthy() {
+        if (!nlpProperties.isEnabled()) return false;
+        try {
+            Map<?, ?> resp = webClientBuilder.build()
+                    .get()
+                    .uri(nlpProperties.getServerUrl() + "/health")
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .block(Duration.ofSeconds(5));
+            return resp != null && "ok".equals(resp.get("status"));
+        } catch (Exception e) {
+            log.debug("[NlpClient] Health check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/growth/_OK/backend/game/controller/NlpStatusController.java
+++ b/backend/src/main/java/growth/_OK/backend/game/controller/NlpStatusController.java
@@ -1,4 +1,36 @@
 package growth._OK.backend.game.controller;
 
+import growth._OK.backend.game.client.NlpClient;
+import growth._OK.backend.global.config.NlpProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 로컬 테스트용 — NLP 서버 연결 상태 확인
+ * GET /nlp/status
+ */
+@RestController
+@RequestMapping("/nlp")
+@RequiredArgsConstructor
 public class NlpStatusController {
+
+    private final NlpClient nlpClient;
+    private final NlpProperties nlpProperties;
+
+    @GetMapping("/status")
+    public ResponseEntity<Map<String, Object>> status() {
+        boolean healthy = nlpClient.isHealthy();
+        return ResponseEntity.ok(Map.of(
+                "nlpEnabled",   nlpProperties.isEnabled(),
+                "serverUrl",    nlpProperties.getServerUrl(),
+                "nlpHealthy",   healthy,
+                "mode",         healthy ? "RAG (NLP Server)" : "Fallback (Gemini Direct)"
+        ));
+    }
 }
+

--- a/backend/src/main/java/growth/_OK/backend/game/controller/NlpStatusController.java
+++ b/backend/src/main/java/growth/_OK/backend/game/controller/NlpStatusController.java
@@ -1,0 +1,4 @@
+package growth._OK.backend.game.controller;
+
+public class NlpStatusController {
+}

--- a/backend/src/main/java/growth/_OK/backend/game/service/GameGenerateService.java
+++ b/backend/src/main/java/growth/_OK/backend/game/service/GameGenerateService.java
@@ -1,6 +1,7 @@
 package growth._OK.backend.game.service;
 
 import growth._OK.backend.auth.jwt.CustomUserDetails;
+import growth._OK.backend.game.client.NlpClient;
 import growth._OK.backend.game.domain.Game;
 import growth._OK.backend.game.domain.GameSource;
 import growth._OK.backend.game.domain.Problem;
@@ -16,6 +17,7 @@ import growth._OK.backend.user.domain.User;
 import growth._OK.backend.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameGenerateService {
@@ -31,6 +34,7 @@ public class GameGenerateService {
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
     private final GeminiService geminiService;
+    private final NlpClient nlpClient;          // ← 추가
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -73,6 +77,7 @@ public class GameGenerateService {
             throw new CapstonException(ExceptionCode.GAME_SOURCE_NOT_SET);
         }
 
+        // 이미 생성된 문제가 있으면 그대로 반환
         List<Problem> existing = problemRepository.findByGame_IdOrderBySortOrderAsc(gameId);
         if (!existing.isEmpty()) {
             return existing.stream()
@@ -95,16 +100,17 @@ public class GameGenerateService {
                 : game.getAllowedProblemTypes().isEmpty() ? List.of(ProblemType.MULTIPLE_CHOICE) : game.getAllowedProblemTypes();
 
         String sourceText = game.getSource().getExtractedText();
-        List<GeminiService.RawGeneratedProblem> rawList = geminiService.generateProblemsFromSource(
-                sourceText,
-                count,
-                types,
-                game.getLearningObjectives()
+
+        // ── RAG Pipeline: NLP 서버 우선 호출 → 실패 시 Gemini fallback ─────────
+        List<GeminiService.RawGeneratedProblem> rawList = generateProblemsWithFallback(
+                sourceText, count, types, game.getLearningObjectives()
         );
+
         if (rawList.size() > count) {
             rawList = new ArrayList<>(rawList.subList(0, count));
         }
 
+        // DB 저장
         List<Problem> saved = new ArrayList<>();
         for (int i = 0; i < rawList.size(); i++) {
             GeminiService.RawGeneratedProblem raw = rawList.get(i);
@@ -122,6 +128,8 @@ public class GameGenerateService {
                     .build();
             saved.add(problemRepository.save(problem));
         }
+
+        // 부족한 문제 패딩
         for (int i = rawList.size(); i < count; i++) {
             Problem problem = Problem.builder()
                     .game(game)
@@ -148,6 +156,38 @@ public class GameGenerateService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * RAG Pipeline 실행:
+     * 1. NLP 서버(FastAPI) 호출 시도
+     * 2. 실패(서버 다운 / nlp.enabled=false) 시 → 기존 Gemini 직접 호출
+     */
+    private List<GeminiService.RawGeneratedProblem> generateProblemsWithFallback(
+            String sourceText, int count, List<ProblemType> types, String learningObjectives) {
+
+        // 1. NLP 서버 시도
+        try {
+            List<GeminiService.RawGeneratedProblem> nlpResult = nlpClient.generateProblems(
+                    sourceText,
+                    null,               // grammar_tags: corpus 자동 검색
+                    count,
+                    types,
+                    learningObjectives  // personalization_context로 전달
+            );
+            if (nlpResult != null && !nlpResult.isEmpty()) {
+                log.info("[GameGenerateService] NLP 서버로 문제 {}개 생성 완료", nlpResult.size());
+                return nlpResult;
+            }
+        } catch (Exception e) {
+            log.warn("[GameGenerateService] NLP 서버 호출 실패, Gemini fallback: {}", e.getMessage());
+        }
+
+        // 2. Gemini fallback (기존 로직 그대로)
+        log.info("[GameGenerateService] Gemini 직접 호출로 문제 생성");
+        return geminiService.generateProblemsFromSource(sourceText, count, types, learningObjectives);
+    }
+
+    // ── 유틸 (기존과 동일) ───────────────────────────────────────────────────
+
     private static ProblemType parseProblemType(String type) {
         if (type == null) return ProblemType.MULTIPLE_CHOICE;
         try {
@@ -171,7 +211,8 @@ public class GameGenerateService {
             return List.of();
         }
         try {
-            return java.util.Arrays.asList(optionsJson.replace("[", "").replace("]", "").replace("\"", "").split(","));
+            return java.util.Arrays.asList(
+                    optionsJson.replace("[", "").replace("]", "").replace("\"", "").split(","));
         } catch (Exception e) {
             return List.of();
         }

--- a/backend/src/main/java/growth/_OK/backend/global/config/NlpProperties.java
+++ b/backend/src/main/java/growth/_OK/backend/global/config/NlpProperties.java
@@ -1,0 +1,17 @@
+package growth._OK.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "nlp")
+public class NlpProperties {
+
+    private String serverUrl = "http://localhost:8000";
+    private int timeoutSeconds = 60;
+    private boolean enabled = true;  // false 로 설정하면 Gemini 직접 호출로 fallback
+}

--- a/backend/src/main/java/growth/_OK/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/growth/_OK/backend/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/google", "/auth/refresh", "/error").permitAll()
+                        .requestMatchers("/auth/google", "/auth/refresh", "/error", "/nlp/status", "/nlp/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -45,3 +45,7 @@ gemini:
 app:
   # 클래스룸 과제 설명에 포함되는 게임 플레이 URL의 origin (경로는 /games/{id} 로 붙습니다)
   frontend-base-url: ${FRONTEND_BASE_URL:http://localhost:5173}
+nlp:
+  server-url: ${NLP_SERVER_URL:http://localhost:8000}
+  timeout-seconds: 60
+  enabled: ${NLP_ENABLED:true}

--- a/front/WebPage/package-lock.json
+++ b/front/WebPage/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webpage",
       "version": "0.0.0",
       "dependencies": {
+        "phaser": "^3.90.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.0"
@@ -55,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1430,7 +1430,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1472,7 +1471,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,7 +1576,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1813,7 +1810,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1991,6 +1987,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2487,6 +2489,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/phaser": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
+      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2500,7 +2511,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2562,7 +2572,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2572,7 +2581,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2841,7 +2849,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2963,7 +2970,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/front/WebPage/vite.config.js
+++ b/front/WebPage/vite.config.js
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      // 🚨 기존 '/auth' 에서 아래처럼 더 구체적으로 바꿔주세요!
       "/auth/google": {
         target: "http://localhost:8080",
         changeOrigin: true,
@@ -16,10 +15,22 @@ export default defineConfig({
         changeOrigin: true,
       },
       "/games": {
-        target: "http://localhost:8080", // 실제 백엔드 주소
+        target: "http://localhost:8080",
         changeOrigin: true,
       },
       "/users": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+      "/analysis": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+      "/classroom": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+      "/nlp": {
         target: "http://localhost:8080",
         changeOrigin: true,
       },


### PR DESCRIPTION
## 개요
FastAPI NLP 서버(Grammar RAG Engine)를 SpringBoot와 연동하고,
프론트엔드 Vite Proxy 설정을 보완합니다.

## 주요 변경사항

### 🔗 SpringBoot ↔ FastAPI 연동
- `NlpProperties.java` 추가 — NLP 서버 URL, timeout, enabled 설정
- `NlpClient.java` 추가 — FastAPI `POST /api/generate/problems` WebClient 호출
- `GameGenerateService.java` 수정 — NLP 서버 우선 호출 + Gemini fallback
- `NlpStatusController.java` 추가 — `GET /nlp/status` 연결 상태 확인
- `application.yml` 수정 — nlp 설정 블록 추가

### 🔒 Security
- `SecurityConfig.java` 수정 — `/nlp/**` 인증 없이 접근 가능하도록 허용

### 🌐 프론트엔드
- `vite.config.js` 수정 — `/analysis`, `/classroom`, `/nlp` proxy 추가
- `package-lock.json` 업데이트

## 테스트 결과
- `GET /nlp/status` → `nlpHealthy: true` 확인 ✅
- FastAPI rule-based 5지선다 문제 생성 확인 ✅
- SpringBoot → FastAPI RAG 파이프라인 연동 확인 ✅
- EC2 systemd 배포 완료 ✅

## 관련 레포
- Grammar-RAG-Engine: `feature/rag-pipeline` 머지 완료