### PR TITLE
feat: 영문법/영단어 분기 및 오답 피드백 개선

### DIFF
--- a/backend/src/main/java/growth/_OK/backend/game/client/NlpClient.java
+++ b/backend/src/main/java/growth/_OK/backend/game/client/NlpClient.java
@@ -15,12 +15,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-/**
- * FastAPI NLP 서버 클라이언트
- * POST /api/generate/problems → GeminiService.RawGeneratedProblem 리스트로 변환
- *
- * nlp.enabled=false 이거나 서버 응답 실패 시 null 반환 → GameGenerateService에서 Gemini fallback
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -30,8 +24,6 @@ public class NlpClient {
     private final WebClient.Builder webClientBuilder;
     private final ObjectMapper objectMapper;
 
-    // ── FastAPI 요청 body ──────────────────────────────────────────────────────
-
     public record NlpGenerateRequest(
             @JsonProperty("source_text")    String sourceText,
             @JsonProperty("grammar_tags")   List<String> grammarTags,
@@ -40,34 +32,22 @@ public class NlpClient {
             @JsonProperty("personalization_context") String personalizationContext
     ) {}
 
-    // ── FastAPI 응답 body ─────────────────────────────────────────────────────
-
     public record NlpProblem(
             String question,
             List<String> options,
-            @JsonProperty("correct_answer") String correctAnswer,
+            @JsonProperty("correct_answer")      String correctAnswer,
+            @JsonProperty("sentence_with_blank") String sentenceWithBlank,
+            String explanation,   // ← FastAPI의 해설 필드 추가
             String type,
             String scope
     ) {}
 
     public record NlpGenerateResponse(
             List<NlpProblem> problems,
-            @JsonProperty("source_sentences") List<String> sourceSentences,
+            @JsonProperty("source_sentences")  List<String> sourceSentences,
             @JsonProperty("grammar_tags_used") List<String> grammarTagsUsed
     ) {}
 
-    // ── 핵심 메서드 ────────────────────────────────────────────────────────────
-
-    /**
-     * FastAPI 서버에 문제 생성 요청.
-     *
-     * @param sourceText             사용자 업로드 텍스트 (null 가능 — corpus에서 자동 검색)
-     * @param grammarTags            취약점 기반 grammar tag 목록 (null 가능)
-     * @param problemCount           생성할 문제 수
-     * @param problemTypes           문제 유형 목록
-     * @param personalizationContext AnalysisService에서 만든 사용자 취약점 JSON 문자열
-     * @return 파싱된 문제 목록. 실패 시 null 반환 → 호출부에서 Gemini fallback 처리
-     */
     public List<GeminiService.RawGeneratedProblem> generateProblems(
             String sourceText,
             List<String> grammarTags,
@@ -122,10 +102,6 @@ public class NlpClient {
         }
     }
 
-    /**
-     * FastAPI 응답 → GeminiService.RawGeneratedProblem 변환
-     * 기존 GameGenerateService 로직을 그대로 재사용할 수 있게 맞춤
-     */
     private GeminiService.RawGeneratedProblem toRaw(NlpProblem p) {
         GeminiService.RawGeneratedProblem raw = new GeminiService.RawGeneratedProblem();
         raw.question      = p.question();
@@ -133,14 +109,10 @@ public class NlpClient {
         raw.correctAnswer = p.correctAnswer();
         raw.type          = p.type();
         raw.scope         = p.scope();
+        raw.explanation   = p.explanation();   // ← FastAPI 해설 매핑
         return raw;
     }
 
-    // ── 헬스체크 ───────────────────────────────────────────────────────────────
-
-    /**
-     * NLP 서버 상태 확인 (로컬 테스트용)
-     */
     public boolean isHealthy() {
         if (!nlpProperties.isEnabled()) return false;
         try {

--- a/backend/src/main/java/growth/_OK/backend/game/service/GameGenerateService.java
+++ b/backend/src/main/java/growth/_OK/backend/game/service/GameGenerateService.java
@@ -4,6 +4,7 @@ import growth._OK.backend.auth.jwt.CustomUserDetails;
 import growth._OK.backend.game.client.NlpClient;
 import growth._OK.backend.game.domain.Game;
 import growth._OK.backend.game.domain.GameSource;
+import growth._OK.backend.game.domain.GameType;
 import growth._OK.backend.game.domain.Problem;
 import growth._OK.backend.game.domain.ProblemType;
 import growth._OK.backend.game.dto.ResponseDto.GamePreviewResponseDto;
@@ -34,7 +35,7 @@ public class GameGenerateService {
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
     private final GeminiService geminiService;
-    private final NlpClient nlpClient;          // ← 추가
+    private final NlpClient nlpClient;
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -101,10 +102,18 @@ public class GameGenerateService {
 
         String sourceText = game.getSource().getExtractedText();
 
-        // ── RAG Pipeline: NLP 서버 우선 호출 → 실패 시 Gemini fallback ─────────
-        List<GeminiService.RawGeneratedProblem> rawList = generateProblemsWithFallback(
-                sourceText, count, types, game.getLearningObjectives()
-        );
+        // ── 영문법 vs 영단어 분기 ──────────────────────────────────────────────
+        List<GeminiService.RawGeneratedProblem> rawList;
+
+        if (GameType.GRAMMAR.equals(game.getType())) {
+            // 영문법 → FastAPI RAG 파이프라인 (NLP 서버 우선, 실패 시 Gemini fallback)
+            log.info("[GameGenerateService] 영문법 게임 - FastAPI RAG 파이프라인 호출");
+            rawList = generateProblemsWithFallback(sourceText, count, types, game.getLearningObjectives());
+        } else {
+            // 영단어 → GeminiService 직접 호출 (영단어 전용 프롬프트)
+            log.info("[GameGenerateService] 영단어 게임 - Gemini 직접 호출");
+            rawList = geminiService.generateProblemsFromSource(sourceText, count, types, game.getLearningObjectives());
+        }
 
         if (rawList.size() > count) {
             rawList = new ArrayList<>(rawList.subList(0, count));
@@ -124,7 +133,7 @@ public class GameGenerateService {
                     .correctAnswer(raw.correctAnswer != null ? raw.correctAnswer : "")
                     .type(pt)
                     .scope(raw.scope != null && !raw.scope.isBlank() ? raw.scope : "기타")
-                    .explanation(null)
+                    .explanation(raw.explanation)
                     .build();
             saved.add(problemRepository.save(problem));
         }
@@ -157,21 +166,20 @@ public class GameGenerateService {
     }
 
     /**
-     * RAG Pipeline 실행:
+     * 영문법 RAG Pipeline:
      * 1. NLP 서버(FastAPI) 호출 시도
-     * 2. 실패(서버 다운 / nlp.enabled=false) 시 → 기존 Gemini 직접 호출
+     * 2. 실패 시 → Gemini fallback
      */
     private List<GeminiService.RawGeneratedProblem> generateProblemsWithFallback(
             String sourceText, int count, List<ProblemType> types, String learningObjectives) {
 
-        // 1. NLP 서버 시도
         try {
             List<GeminiService.RawGeneratedProblem> nlpResult = nlpClient.generateProblems(
                     sourceText,
-                    null,               // grammar_tags: corpus 자동 검색
+                    null,
                     count,
                     types,
-                    learningObjectives  // personalization_context로 전달
+                    learningObjectives
             );
             if (nlpResult != null && !nlpResult.isEmpty()) {
                 log.info("[GameGenerateService] NLP 서버로 문제 {}개 생성 완료", nlpResult.size());
@@ -181,12 +189,11 @@ public class GameGenerateService {
             log.warn("[GameGenerateService] NLP 서버 호출 실패, Gemini fallback: {}", e.getMessage());
         }
 
-        // 2. Gemini fallback (기존 로직 그대로)
-        log.info("[GameGenerateService] Gemini 직접 호출로 문제 생성");
+        log.info("[GameGenerateService] Gemini fallback으로 문제 생성");
         return geminiService.generateProblemsFromSource(sourceText, count, types, learningObjectives);
     }
 
-    // ── 유틸 (기존과 동일) ───────────────────────────────────────────────────
+    // ── 유틸 ─────────────────────────────────────────────────────────────────
 
     private static ProblemType parseProblemType(String type) {
         if (type == null) return ProblemType.MULTIPLE_CHOICE;


### PR DESCRIPTION
## 개요
영문법과 영단어 문제 생성 파이프라인을 분리하고,
FastAPI에서 생성한 해설을 DB에 저장하여 오답 복습 시 1대1 피드백을 제공합니다.

## 변경사항

### GameGenerateService.java
- 영문법(GRAMMAR) → FastAPI RAG 파이프라인 호출
- 영단어(VOCAB) → GeminiService 직접 호출
- `.explanation(raw.explanation)` — FastAPI 해설 DB 저장

### GeminiService.java
- 영단어 전용 프롬프트 추가 (vocabGuide)
- `RawGeneratedProblem`에 `explanation` 필드 추가
- 해설 마크다운 금지 추가

### NlpClient.java
- `NlpProblem`에 `explanation`, `sentenceWithBlank` 필드 추가
- `toRaw()`에서 `explanation` 매핑 추가